### PR TITLE
feat: generate `html format`

### DIFF
--- a/data_processor/__init__.py
+++ b/data_processor/__init__.py
@@ -1,3 +1,4 @@
 from .data_loader import load_data, fetch_multiple_pages_kmdb, generate_params
 from .data_filter import filter_weekly_release, extract_movie_details
 from .data_summarizer import summarize_release
+from .html_generator import generate_html

--- a/data_processor/html_generator.py
+++ b/data_processor/html_generator.py
@@ -1,0 +1,50 @@
+from typing import List, Dict
+from datetime import datetime
+
+DATE_FORMAT = "%Y-%m-%d"
+
+def load_template(template_path: str) -> str:
+    with open(template_path, "r", encoding="utf-8") as template_file:
+        return template_file.read()
+
+def make_movie_card(movie_id: str, movie: Dict[str, str], template: str) -> str:
+    release_date = datetime.strptime(movie["release_date"], "%Y%m%d").strftime(DATE_FORMAT)
+    return template.format(
+        content_id=movie_id,
+        poster_url=movie["posters"].split("|")[0],
+        title=movie["title"],
+        release_date=release_date,
+        genre=movie["genre"],
+        directors=", ".join(movie["directors"]),
+        cast=", ".join(movie["actors"]),
+        synopsis=''.join(movie["plots"]),
+    )
+
+def make_index_block(movie_id: str, movie: Dict[str, str], template: str) -> str:
+    release_date = datetime.strptime(movie["release_date"], "%Y%m%d").strftime(DATE_FORMAT)
+    return template.format(
+        content_id=movie_id,
+        title=movie["title"],
+        poster_url=movie["posters"].split("|")[0],
+        release_date=release_date,
+        genre=movie["genre"],
+    )
+
+def generate_html(template_path: str, data: List[Dict[str, str]]) -> str:
+    movie_card = load_template(template_path+"movie_card.html")
+    top_index = load_template(template_path+"top_index.html")
+    index_blocks = []
+    movie_blocks = []
+
+    for idx, movie in enumerate(data):
+        print(movie["title"])
+        movie_id = f"movie{idx + 1}"
+        movie_block = make_movie_card(movie_id, movie, movie_card)
+        index_block = make_index_block(movie_id, movie, top_index)
+        movie_blocks.append(movie_block)
+        index_blocks.append(index_block)
+
+    complete_index = "\n".join(index_blocks)
+    complete_mcards = "\n".join(movie_blocks)
+
+    return complete_index, complete_mcards

--- a/main.py
+++ b/main.py
@@ -5,6 +5,7 @@ from data_processor import (
     summarize_release,
     fetch_multiple_pages_kmdb,
     extract_movie_details,
+    generate_html,
 )
 
 
@@ -39,7 +40,22 @@ def main_kmdb():
 
     data = fetch_multiple_pages_kmdb(api_url, params=params)
     movie_details = extract_movie_details(data)
+    index_body, mcards = generate_html("templates/", movie_details)
 
+    with open("Aug3rd.html", "w") as output_file:
+        output_file.write(
+            """
+            <div style="max-width: 600px; margin: auto; padding: 10px; font-family: 'Nunito', sans-serif;">
+<div style="text-align: center; margin-bottom: 20px;">
+<p style="font-size: 24px; font-weight: bold; color: #333;" data-ke-size="size16">주간 개봉 영화</p>
+</div>
+<div style="margin-bottom: 20px; border: 2px solid #ccc; border-radius: 10px; padding: 15px; background-color: #f9f9f9;">
+<p style="font-size: 18px; font-weight: bold; color: #007bff;" data-ke-size="size16">목차</p>
+            """
+        )
+        output_file.write(index_body)
+        output_file.write("</div>")
+        output_file.write(mcards)
 
 if __name__ == "__main__":
     main_kmdb()

--- a/templates/movie_card.html
+++ b/templates/movie_card.html
@@ -1,0 +1,11 @@
+<div id="{content_id}" style="padding: 15px; border: 2px solid #ccc; border-radius: 10px; margin-bottom: 20px; background-color: #f9f9f9;">
+    <div style="text-align: center;">
+        <img style="width: 200; height: 297; border-radius: 10px; margin-bottom: 15px;" src="{poster_url}" alt="{title} 포스터" />
+    </div>
+    <p style="font-size: 20px; font-weight: bold; color: #007bff;" data-ke-size="size16">{title}</p>
+    <p style="font-size: 14px; color: #555;" data-ke-size="size16"><b>개봉일</b>: {release_date}</p>
+    <p style="font-size: 14px; color: #555;" data-ke-size="size16"><b>장르</b>: {genre}</p>
+    <p style="font-size: 14px; color: #555;" data-ke-size="size16"><b>감독</b>: {directors}</p>
+    <p style="font-size: 14px; color: #555;" data-ke-size="size16"><b>출연</b>: {cast}</p>
+    <p style="font-size: 14px; color: #333; margin-top: 10px;" data-ke-size="size16"><b>줄거리</b>: {synopsis}</p>
+</div>

--- a/templates/top_index.html
+++ b/templates/top_index.html
@@ -1,0 +1,11 @@
+<div style="display: flex; flex-direction: column; gap: 15px;">
+<div style="display: flex; align-items: center;">
+<div style="flex-shrink: 0; width: 100px; height: 150px; overflow: hidden; border-radius: 10px; margin-right: 15px;">[##_Image|{poster_url}|CDM|1.3|_##]</div>
+<div>
+<p style="font-size: 16px; font-weight: bold; margin: 0;" data-ke-size="size16"><a style="text-decoration: none; color: #007bff;" href="#{content_id}">{title}</a></p>
+<p style="font-size: 14px; color: #555; margin: 5px 0;" data-ke-size="size16"><b>개봉일</b>: {release_date}</p>
+<p style="font-size: 14px; color: #555; margin: 0;" data-ke-size="size16"><b>장르</b>: {genre}</p>
+</div>
+<p data-ke-size="size16">&nbsp;</p>
+</div>
+</div>


### PR DESCRIPTION
## 설명
`html generator`를 추가하였습니다. `KMDB api`에서 불러온 데이터를 html로 작성할 수 있습니다.
## 변경 사항
- `top_index.html`: 페이지의 상위 목차 템플릿입니다.
- `movie_card.html`: 페이지의 영화 카드 템플릿입니다.
- `html_generator.py`: `html`템플릿을 불러오고, 템플릿에 맞춰서 `api data`를 입력합니다.
- `main.py`: 최종 html을 작성합니다. (현재는 블로그 포맷으로 되어 있어서, 온전한 html이 아닙니다.)